### PR TITLE
Fix: refine remove DataSourceRegistration logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ bin
 .idea/
 
 grafana-configuration-chart-*
+
+.DS_Store


### PR DESCRIPTION
When grafana or datasources (prometheus/loki) could not be found when
delition, delete the datasourceregistration directly.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>